### PR TITLE
Fix: Crossword clues not displaying

### DIFF
--- a/crossword_island.html
+++ b/crossword_island.html
@@ -158,7 +158,13 @@
         const numberLocations = new Map();
 
         function initializeGrid() {
-            grid = Array(puzzleData.height).fill(null).map(() => Array(puzzleData.width).fill({ letter: null, empty: true, inputs: {} }));
+            grid = [];
+            for (let r = 0; r < puzzleData.height; r++) {
+                grid[r] = [];
+                for (let c = 0; c < puzzleData.width; c++) {
+                    grid[r][c] = { letter: null, empty: true, inputs: {} };
+                }
+            }
 
             // Assign unique numbers to start of words
             let clueNumber = 1;
@@ -183,12 +189,17 @@
                 let c = wordData.col;
 
                 for (let i = 0; i < wordData.word.length; i++) {
+                    if (r >= puzzleData.height || c >= puzzleData.width) {
+                        console.error(`Word "${wordData.word}" is out of bounds.`);
+                        break;
+                    }
+
                     grid[r][c] = {
                         ...grid[r][c],
                         letter: wordData.word[i],
                         empty: false,
+                        inputs: { ...grid[r][c].inputs, [wordData.direction]: true }
                     };
-                    grid[r][c].inputs[wordData.direction] = true;
 
                     if (wordData.direction === 'across') c++;
                     else r++;


### PR DESCRIPTION
The crossword clues were not being displayed due to a bug in the `initializeGrid()` function. The function was using `Array.prototype.fill()` with an object, which caused all cells in a row to share the same object reference. This led to an error when a cell was part of both an "across" and a "down" word, as the `inputs` property was being overwritten.

Additionally, some of the puzzle data was out of bounds, causing the code to access array elements that don't exist.

The fix replaces the faulty grid initialization with a nested loop that creates a unique object for each cell. It also adds a guard to prevent out-of-bounds access and correctly merges the `inputs` property when a cell is part of both an "across" and a "down" word.